### PR TITLE
add z thru to drill depth

### DIFF
--- a/src/mode/cam/prepare.js
+++ b/src/mode/cam/prepare.js
@@ -201,7 +201,7 @@
                     break;
                 }
             }
-            camOut(point.clone().setZ(zmax));
+            camOut(point.clone().setZ(zmax_outer));
             points.forEach(function(point, index) {
                 camOut(point, 1);
                 if (index > 0 && index < points.length - 1) {
@@ -209,7 +209,7 @@
                     if (lift) camOut(point.clone().setZ(point.z + lift), 0);
                 }
             })
-            camOut(point.clone().setZ(zmax));
+            camOut(point.clone().setZ(zmax_outer));
             newLayer();
         }
 


### PR DESCRIPTION
Take "Z thru" limit into account when drilling, if set, to ensure holes go through fully.

I think this makes sense and is what people would expect when adjusting the "Z thru" limit. Until now, only the cutout pass of the outline tool respected this value.
